### PR TITLE
fix(): prettier now properly allows double quotes in scss files

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,12 @@
 module.exports = {
   singleQuote: true,
   trailingComma: 'all',
+  overrides: [
+    {
+      files: '*.scss',
+      options: {
+        singleQuote: false,
+      },
+    },
+  ],
 };


### PR DESCRIPTION
- matches stylelint requirement