### PR TITLE
feat: add experimental shadow depth for use in product page

### DIFF
--- a/packages/theme/src/abstracts/_shadows.scss
+++ b/packages/theme/src/abstracts/_shadows.scss
@@ -1,6 +1,9 @@
 // Shadows
 // ------------------------------------ *
 $depth1: 0 1px 0 0 rgba(185, 200, 212, 0.5); //border: 1px solid #D8DBE1;
-$depth2: 0 3px 6px 0 rgba(183, 183, 183, 0.5), 0 1px 0 0 rgba(223, 223, 223, 0.5); //border: 1px solid #BFCFDB;
-$depth3: 0 37px 60px 10px #D7E0E5;
+$depth2: 0 3px 6px 0 rgba(183, 183, 183, 0.5),
+  0 1px 0 0 rgba(223, 223, 223, 0.5); //border: 1px solid #BFCFDB;
+$depth3: 0 37px 60px 10px #d7e0e5;
 $depth4: 0 0 0 1px rgba(63, 63, 68, 0.05), 0 1px 3px 0 rgba(63, 63, 68, 0.15);
+$depth5: 0 3px 9px 0 rgba(42, 47, 69, 0.1), 0 2px 5px 0 rgba(42, 47, 69, 0.08),
+  0 1px 1.5px 0 rgba(0, 0, 0, 0.08), 0 1px 2px 0 rgba(0, 0, 0, 0.08); // DO NOT USE expiramental product page

--- a/src/Foundations/Variables.mdx
+++ b/src/Foundations/Variables.mdx
@@ -107,23 +107,25 @@ Use spacing to control margins, paddings and other standardized spaces using our
 
 ## Borders
 
-| Variable               | Description                   |
-| ---------------------- | ----------------------------- |
-| `$standard-border`     | apply a standard color border |
-| `$brand-border`        | apply a brand color border    |
-| `$radius-s`            | border-radius                 |
-| `$radius-m`            | border-radius                 |
-| `$radius-l`            | border-radius                 |
-| `$width-s`             | set border thickness          |
-| `$width-m`             | set border thickness          |
-| `$width-l`             | set border thickness          |
-| `$style`               | border-radius                 |
-| `$depth1`              | shallow drop shadow           |
-| `$depth2`              | medium drop shadow            |
-| `$depth3`              | deep drop shadow              |
-| `$border-radius-small` | `3px`                         |
-| `$border-radius-base`  | `8px`                         |
-| `$border-radius-large` | `24px`                        |
+| Variable               | Description                            |
+| ---------------------- | -------------------------------------- |
+| `$standard-border`     | apply a standard color border          |
+| `$brand-border`        | apply a brand color border             |
+| `$radius-s`            | border-radius                          |
+| `$radius-m`            | border-radius                          |
+| `$radius-l`            | border-radius                          |
+| `$width-s`             | set border thickness                   |
+| `$width-m`             | set border thickness                   |
+| `$width-l`             | set border thickness                   |
+| `$style`               | border-radius                          |
+| `$depth1`              | shallow drop shadow                    |
+| `$depth2`              | medium drop shadow                     |
+| `$depth3`              | deep drop shadow                       |
+| `$depth4`              | ?                                      |
+| `$depth5`              | expiramental product page (do not use) |
+| `$border-radius-small` | `3px`                                  |
+| `$border-radius-base`  | `8px`                                  |
+| `$border-radius-large` | `24px`                                 |
 
 ## Colors
 


### PR DESCRIPTION
Shadow to be used on the bluesky product page.  UX wants to use the bluesky product page shadow depth as a possible role model for future product pages.