### PR TITLE
fix(): local file refs created issue with pkgs digested externally

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,6 @@
   "license": "MIT",
   "version": "0.0.0",
   "private": true,
-  "dependencies": {
-    "eslint": "^5.16.0",
-    "null": "^1.0.1",
-    "react": "^16.8.0",
-    "react-bootstrap": "^0.32.4",
-    "react-content-loader": "^4.2.1",
-    "react-dom": "^16.8.0",
-    "react-scripts": "3.0.1",
-    "typescript": "*"
-  },
   "scripts": {
     "start": "docz dev",
     "build": "docz build",
@@ -40,6 +30,7 @@
     "@eigi/bluebird-fastdomain": "file:packages/bluebird-fastdomain",
     "@eigi/bluebird-hostmonster": "file:packages/bluebird-hostmonster",
     "@eigi/bluebird-justhost": "file:packages/bluebird-justhost",
+    "@eigi/bluebird-theme-default": "file:packages/bluebird-theme-default",
     "@eigi/eslint-config": "0.0.0",
     "@eigi/stylelint-config": "file:packages/stylelint-config",
     "@emotion/cache": "^10.0.0",
@@ -50,8 +41,16 @@
     "docz-core": "1.2.0",
     "docz-plugin-css": "^0.11.0",
     "docz-theme-default": "1.2.0",
+    "eslint": "^5.16.0",
     "husky": "^2.5.0",
     "lerna": "^3.15.0",
+    "null": "^1.0.1",
+    "react": "^16.8.0",
+    "react-bootstrap": "^0.32.4",
+    "react-content-loader": "^4.2.1",
+    "react-dom": "^16.8.0",
+    "react-scripts": "3.0.1",
+    "typescript": "*",
     "webpack": "^4.34.0"
   },
   "husky": {

--- a/packages/bluebird-bluehost/package.json
+++ b/packages/bluebird-bluehost/package.json
@@ -5,13 +5,6 @@
   "description": "Bluebird theme for Bluehost",
   "main": "index.js",
   "author": "Endurance International Group",
-  "dependencies": {
-    "@eigi/bluebird": "file:../bluebird"
-  },
-  "devDependencies": {
-    "@eigi/eslint-config": "0.0.0",
-    "@eigi/stylelint-config": "file:../stylelint-config"
-  },
   "eslintConfig": {
     "extends": "@eigi/eslint-config"
   },

--- a/packages/bluebird-fastdomain/package.json
+++ b/packages/bluebird-fastdomain/package.json
@@ -5,13 +5,6 @@
   "description": "Bluebird theme for FastDomain",
   "main": "index.js",
   "author": "Endurance International Group",
-  "dependencies": {
-    "@eigi/bluebird": "file:../bluebird"
-  },
-  "devDependencies": {
-    "@eigi/eslint-config": "0.0.0",
-    "@eigi/stylelint-config": "file:../stylelint-config"
-  },
   "eslintConfig": {
     "extends": "@eigi/eslint-config"
   },

--- a/packages/bluebird-hostmonster/package.json
+++ b/packages/bluebird-hostmonster/package.json
@@ -5,13 +5,6 @@
   "description": "Bluebird theme for HostMonster",
   "main": "index.js",
   "author": "Endurance International Group",
-  "dependencies": {
-    "@eigi/bluebird": "file:../bluebird"
-  },
-  "devDependencies": {
-    "@eigi/eslint-config": "0.0.0",
-    "@eigi/stylelint-config": "file:../stylelint-config"
-  },
   "eslintConfig": {
     "extends": "@eigi/eslint-config"
   },

--- a/packages/bluebird-justhost/package.json
+++ b/packages/bluebird-justhost/package.json
@@ -5,13 +5,6 @@
   "description": "Bluebird theme for Justhost",
   "main": "index.js",
   "author": "Endurance International Group",
-  "dependencies": {
-    "@eigi/bluebird": "file:../bluebird"
-  },
-  "devDependencies": {
-    "@eigi/eslint-config": "0.0.0",
-    "@eigi/stylelint-config": "file:../stylelint-config"
-  },
   "eslintConfig": {
     "extends": "@eigi/eslint-config"
   },

--- a/packages/bluebird-theme-default/package.json
+++ b/packages/bluebird-theme-default/package.json
@@ -1,17 +1,10 @@
 {
   "name": "@eigi/bluebird-theme-default",
   "license": "MIT",
-  "version": "1.3.3",
+  "version": "1.3.0",
   "description": "Bluebird theme default",
   "main": "index.js",
   "author": "Endurance International Group",
-  "dependencies": {
-    "@eigi/bluebird": "file:../bluebird"
-  },
-  "devDependencies": {
-    "@eigi/eslint-config": "0.0.0",
-    "@eigi/stylelint-config": "file:../stylelint-config"
-  },
   "eslintConfig": {
     "extends": "@eigi/eslint-config"
   },

--- a/packages/bluebird/package.json
+++ b/packages/bluebird/package.json
@@ -5,12 +5,7 @@
   "main": "src/index.js",
   "description": "Bluebird UI",
   "dependencies": {
-    "bluebird-theme-default": "file:../bluebird-theme-default",
     "bootstrap-sass": "^3.4.0"
-  },
-  "devDependencies": {
-    "@eigi/eslint-config": "0.0.0",
-    "@eigi/stylelint-config": "file:../stylelint-config"
   },
   "eslintConfig": {
     "extends": "@eigi/eslint-config"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,29 +1347,23 @@
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
 "@eigi/bluebird-bluehost@file:packages/bluebird-bluehost":
-  version "1.3.0"
-  dependencies:
-    "@eigi/bluebird" "file:../../Library/Caches/Yarn/v4/npm-@eigi-bluebird-bluehost-1.3.0-67c07f08-355d-4b09-bb83-65852549124f-1566840757219/node_modules/@eigi/bluebird"
+  version "1.3.3"
 
 "@eigi/bluebird-fastdomain@file:packages/bluebird-fastdomain":
-  version "1.3.0"
-  dependencies:
-    "@eigi/bluebird" "file:../../Library/Caches/Yarn/v4/npm-@eigi-bluebird-fastdomain-1.3.0-b69c53c8-6d59-4674-af05-9f48b018274f-1566840757222/node_modules/@eigi/bluebird"
+  version "1.3.3"
 
 "@eigi/bluebird-hostmonster@file:packages/bluebird-hostmonster":
-  version "1.3.0"
-  dependencies:
-    "@eigi/bluebird" "file:../../Library/Caches/Yarn/v4/npm-@eigi-bluebird-hostmonster-1.3.0-be633aeb-d723-4e65-b3c5-22408d3250a4-1566840757224/node_modules/@eigi/bluebird"
+  version "1.3.3"
 
 "@eigi/bluebird-justhost@file:packages/bluebird-justhost":
+  version "1.3.3"
+
+"@eigi/bluebird-theme-default@file:packages/bluebird-theme-default":
   version "1.3.0"
-  dependencies:
-    "@eigi/bluebird" "file:../../Library/Caches/Yarn/v4/npm-@eigi-bluebird-justhost-1.3.0-509496e0-1a1c-4cbe-89c0-934806998e43-1566840757226/node_modules/@eigi/bluebird"
 
 "@eigi/bluebird@file:packages/bluebird":
-  version "1.3.2"
+  version "1.3.3"
   dependencies:
-    bluebird-theme-default "file:../../Library/Caches/Yarn/v4/npm-@eigi-bluebird-1.3.2-818d3981-4ddc-4cdc-88c4-e51d6713f2b7-1566840757214/node_modules/@eigi/bluebird-theme-default"
     bootstrap-sass "^3.4.0"
 
 "@eigi/eslint-config@0.0.0":
@@ -3984,11 +3978,6 @@ block-stream@*:
   integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
   dependencies:
     inherits "~2.0.0"
-
-"bluebird-theme-default@file:packages/bluebird-theme-default":
-  version "1.3.0"
-  dependencies:
-    "@eigi/bluebird" "file:../../Library/Caches/Yarn/v4/npm-bluebird-theme-default-1.3.0-933e524f-ecf5-4574-b55a-71cbfb187ed8-1566840757217/node_modules/bluebird"
 
 bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.5.5"


### PR DESCRIPTION
Ran into an issue during `yarn install @eigi/bluebird@1.3.3` due to the local file refs of bluebird-theme-default. In this pull request I have removed that and now there is an undisclosed peerDependency requirement of `bluebird-theme-default` (or another theme) when using bluebird.