### PR TITLE
style(bluebird): updates to color variables

### DIFF
--- a/packages/theme/src/abstracts/_colors.scss
+++ b/packages/theme/src/abstracts/_colors.scss
@@ -3,26 +3,30 @@
 
 // Palette Colors
 // - Grays
-$black: #000;
+$black: #000; // not currently in use
 $gray-base: #576373;
 $gray-darker: #344154;
 $gray-dark: #758397;
 $gray: #9dafbd;
+$gray-bg: #f2f7fa;
 $gray-light: #9dafbd;
 $gray-lighter: #d7dbe0; // lighten($gray-base, 93.5%) !default; // DDE0E6
 $white: #fff;
 
 // - Chromatics
 $snow: #fafbfc;
-$blue-light: #f1f5f7;
 $blue: $brand-primary;
-$blue-dark: #2e66ba;
+$blue-dark: #2a5da8;
+$blue-light: #5e91db;
 $green: $brand-success;
-$green-light: #17b212;
-$green-dark: #17b212;
+$green-light: #46c142;
+$green-dark: #148f10;
 $orange: $brand-warning;
-$orange-light: #f89c24;
+$orange-light: #f9af4f;
+$orange-dark: #c77d1c;
 $red: $brand-danger;
+$red-light: #d93549;
+$red-dark: #a60115;
 $athens: #d7dbe0;
 $water: #bfcfdb;
 $dark-snow: #edf4f9;

--- a/packages/theme/src/abstracts/_variables-bootstrap.scss
+++ b/packages/theme/src/abstracts/_variables-bootstrap.scss
@@ -11,25 +11,25 @@ $white: #fff;
 $black: #000;
 
 // Gray
-$gray-base: #576373;
+$gray-base: #5c5c5c;
 $gray-darker: #344154;
 $gray-dark: #758397;
 $gray: #9dafbd;
-$gray-light: #9dafbd;
-$gray-lighter: #d7dbe0; // lighten($gray-base, 93.5%) !default; // DDE0E6
+$gray-light: #999999;
+$gray-lighter: #d7dbe0; // lighten($gray-base, 93.5%) !default;
 $snow: #fafbfc; // lighten($gray-base, 93.5%) !default;
 
 // jetpack logo color
 $jetpack-primary: #66d975;
 
-$blue-light: #f1f5f7; //F2F7FA
+$gray-bg: #f2f7fa;
 
 //== Scaffolding
 //
 //## Settings for some of the most global styles.
 
 //** Background color for `<body>`.
-$body-bg: $blue-light;
+$body-bg: $gray-bg;
 //** Global text color on `<body>`.
 $text-color: $gray-base;
 
@@ -48,12 +48,14 @@ $default-box-shadow-color: #ccc;
 //
 //## Font, line-height, and color for body text, headings, and more.
 
-$font-family-sans-serif: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif !default;
+$font-family-sans-serif: 'Open Sans', 'Helvetica Neue', Helvetica, Arial,
+  sans-serif !default;
 // $font-family-serif:       Georgia, "Times New Roman", Times, serif !default;
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
 $font-family-monospace: Menlo, Monaco, Consolas, 'Courier New', monospace !default;
 $font-family-base: $font-family-sans-serif !default;
-$font-family-blink-mac: -apple-system, BlinkMacSystemFont, $font-family-sans-serif;
+$font-family-blink-mac: -apple-system, BlinkMacSystemFont,
+  $font-family-sans-serif;
 
 $font-size-base: 16px;
 $font-size-large: ceil(($font-size-base * 1.25)) !default; // ~20px
@@ -91,7 +93,9 @@ $line-height-h2: 40px;
 $line-height-h3: 32px;
 $line-height-h4: 24px;
 //** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
-$line-height-computed: floor(($font-size-base * $line-height-base)) !default; // ~20px
+$line-height-computed: floor(
+  ($font-size-base * $line-height-base)
+) !default; // ~20px
 
 // custom line-heights
 $line-height: $line-height-base;
@@ -113,7 +117,11 @@ $headings-color: inherit !default;
 
 // [converter] If $bootstrap-sass-asset-helper if used, provide path relative to the assets load path.
 // [converter] This is because some asset helpers, such as Sprockets, do not work with file-relative paths.
-$icon-font-path: if($bootstrap-sass-asset-helper, 'bootstrap/', '../fonts/bootstrap/') !default;
+$icon-font-path: if(
+  $bootstrap-sass-asset-helper,
+  'bootstrap/',
+  '../fonts/bootstrap/'
+) !default;
 
 //** File name for all font files.
 $icon-font-name: 'glyphicons-halflings-regular' !default;
@@ -249,14 +257,18 @@ $input-border-focus: $brand-primary !default;
 $input-color-placeholder: $gray !default;
 
 //** Default `.form-control` height
-$input-height-base: ($line-height-computed + ($padding-base-vertical * 2) + 2) !default;
+$input-height-base: (
+  $line-height-computed + ($padding-base-vertical * 2) + 2
+) !default;
 //** Large `.form-control` height
 $input-height-large: (
-  ceil($font-size-large * $line-height-large) + ($padding-large-vertical * 2) + 2
+  ceil($font-size-large * $line-height-large) + ($padding-large-vertical * 2) +
+    2
 ) !default;
 //** Small `.form-control` height
 $input-height-small: (
-  floor($font-size-small * $line-height-small) + ($padding-small-vertical * 2) + 2
+  floor($font-size-small * $line-height-small) + ($padding-small-vertical * 2) +
+    2
 ) !default;
 
 //** `.form-group` margin
@@ -405,7 +417,9 @@ $navbar-height: 48px !default;
 $navbar-margin-bottom: $line-height-computed !default;
 $navbar-border-radius: 0;
 $navbar-padding-horizontal: floor(($grid-gutter-width / 2)) !default;
-$navbar-padding-vertical: (($navbar-height - $line-height-computed) / 2) !default;
+$navbar-padding-vertical: (
+  ($navbar-height - $line-height-computed) / 2
+) !default;
 $navbar-collapse-max-height: 340px !default;
 
 $navbar-default-color: $gray-base !default;
@@ -423,7 +437,10 @@ $navbar-default-link-disabled-bg: transparent !default;
 
 // Navbar brand label
 $navbar-default-brand-color: $navbar-default-link-color !default;
-$navbar-default-brand-hover-color: darken($navbar-default-brand-color, 10%) !default;
+$navbar-default-brand-hover-color: darken(
+  $navbar-default-brand-color,
+  10%
+) !default;
 $navbar-default-brand-hover-bg: transparent !default;
 
 // Navbar toggle
@@ -596,7 +613,10 @@ $popover-arrow-outer-width: ($popover-arrow-width + 1) !default;
 //** Popover outer arrow color
 $popover-arrow-outer-color: fade_in($popover-border-color, 0.05) !default;
 //** Popover outer arrow fallback color
-$popover-arrow-outer-fallback-color: darken($popover-fallback-border-color, 20%) !default;
+$popover-arrow-outer-fallback-color: darken(
+  $popover-fallback-border-color,
+  20%
+) !default;
 
 //== Labels
 //

--- a/packages/theme/src/bootstrap-sass/overrides/_dropdowns.scss
+++ b/packages/theme/src/bootstrap-sass/overrides/_dropdowns.scss
@@ -71,7 +71,7 @@
       &:hover {
         color: $gray-base;
         text-decoration: none;
-        background-color: $blue-light;
+        background-color: $body-bg;
       }
 
       @media (min-width: 768px) {

--- a/src/utils/Colors.js
+++ b/src/utils/Colors.js
@@ -1,12 +1,14 @@
 import React from 'react';
 
 export const Swatch = ({ color, style }) => (
-  <div style={{
-    backgroundColor: color || '#000',
-    height: '50px',
-    width: '50px',
-    ...style,
-  }} />
+  <div
+    style={{
+      backgroundColor: color || '#000',
+      height: '50px',
+      width: '50px',
+      ...style,
+    }}
+  />
 );
 
 const Box = ({ styleProps, children }) => (
@@ -14,28 +16,28 @@ const Box = ({ styleProps, children }) => (
     style={{
       width: '30%',
       textAlign: 'center',
-      content: "",
+      content: '',
       display: 'block',
       padding: '2% 0',
-      ...styleProps
+      ...styleProps,
     }}
   >
     {children}
   </div>
-)
+);
 
-const setPalette = (color) => ({ backgroundColor: color });
+const setPalette = color => ({ backgroundColor: color });
 
 const paletteMap = {
-  primary: { color: '#d8d8d8', text: 'Primary'},
+  primary: { color: '#d8d8d8', text: 'Primary' },
   darkGreen: { color: '#009013', text: 'Dark Green' },
   background: { color: '#f1f5f7', text: 'Background' },
-}
+};
 
 const feedbackMap = {
   actionGreen: { color: '#17b212', text: 'Action Green' },
   actionDanger: { color: '#f72f26', text: 'Action Danger' },
-  actionWarning: { color: '#f89c24', text: 'Action Warning' }
+  actionWarning: { color: '#f89c24', text: 'Action Warning' },
 };
 
 const neutralMap = {
@@ -43,12 +45,12 @@ const neutralMap = {
   lightGray: { color: '#9a9a9a', text: 'Light Gray' },
   lightestGray: { color: '#fafbfc', text: 'Lightest Gray' },
   borderGray: { color: '#d7dbe0', text: 'Border Gray' },
-  white: { color: '#ffffff', text: 'White' }
+  white: { color: '#ffffff', text: 'White' },
 };
 
-const Color = (colorMap) => (
+const Color = colorMap => (
   <React.Fragment>
-    {Object.keys(colorMap).map((color) => (
+    {Object.keys(colorMap).map(color => (
       <Box styleProps={setPalette(colorMap[color].color)}>
         {colorMap[color].text}
         <br />
@@ -56,11 +58,11 @@ const Color = (colorMap) => (
       </Box>
     ))}
   </React.Fragment>
-)
+);
 
-const Palette = () => (Color(paletteMap));
-const Feedback = () => (Color(feedbackMap));
-const Neutral = () => (Color(neutralMap));
+const Palette = () => Color(paletteMap);
+const Feedback = () => Color(feedbackMap);
+const Neutral = () => Color(neutralMap);
 
 export default {
   Palette,


### PR DESCRIPTION
Added and updated some of color variables to make them inline with current Bluebird color values. 

Changed $blue-light to reference the lightened brand blue color, instead of our background color (#F2F4F7). 

Created a new variable $gray-bg for our background color (#F2F4F7).