### PR TITLE
docs(): updates to docs, one slight change to dropdown icon

### DIFF
--- a/packages/bluebird/src/semantic-ui-react/_dropdown.scss
+++ b/packages/bluebird/src/semantic-ui-react/_dropdown.scss
@@ -1480,7 +1480,7 @@
 .ui.dropdown > .dropdown.icon:before {
   content: "\7a";
   position: relative;
-  top: 5px;
+  top: 3px;
   line-height: $line-height-base;
   font-size: 1.125em;
   font-weight: bold;

--- a/src/Components/DropdownButtons.mdx
+++ b/src/Components/DropdownButtons.mdx
@@ -14,7 +14,7 @@ import { Playground } from 'docz';
 
 # DropdownButton
 
-** Note: As of version 1.4.0, it is encouraged to use the new [Dropodown](/src-components-dropdowns) components intead of DropdownButton **
+** Note: As of version 1.5.0, it is encouraged to use the new [Dropdown](/src-components-dropdowns) components intead of DropdownButton **
 
 ## Single button dropdowns ![Experimental Badge](https://img.shields.io/badge/component-experimental-blue.svg#badge)
 

--- a/src/Components/Dropdowns.mdx
+++ b/src/Components/Dropdowns.mdx
@@ -9,6 +9,18 @@ A type of menu that gives users the ability to select from multiple items or to 
 
 Use this in place of other selection elements when the user needs to pick one option from a large set of options. Dropdown menus are appropriate inside forms, but can also be used on pages when a selection is required. (Example: a filter or sorting option)
 
+Install the component dependencies:
+
+`yarn add semantic-ui-react`
+
+`yarn add semantic-ui-css`
+
+
+Include this React component in your project: 
+
+`import Dropdown from 'semantic-ui-react';`
+
+
 ## Types
 
 ### Dropdown 

--- a/src/styles/wrapper.scss
+++ b/src/styles/wrapper.scss
@@ -2,9 +2,18 @@ img[src$="#badge"] {
   width: auto;
 }
 .red-element {
-  background:#F9DBE6;
+  background: #f9dbe6;
 }
 
 .blue-element {
-  background: #BCF4FD;
+  background: #bcf4fd;
+}
+
+code {
+  display: block;
+  background: #2e3440 !important;
+  margin: 8px 0 !important;
+  padding: 16px !important;
+  color: white !important;
+  border-radius: 0 !important;
 }


### PR DESCRIPTION
Updates to the wrapper.scss file are so we can display inline code examples without having to load entire Playground elements. I updated the styling so that these are more obviously code examples. 